### PR TITLE
Extract input arbiter

### DIFF
--- a/Teste/NoC/Thor_switchcontrol.vhd
+++ b/Teste/NoC/Thor_switchcontrol.vhd
@@ -48,9 +48,8 @@ begin
 
     InputArbiter : entity work.inputArbiter
     port map(
-        lastPort => sel,
         requests => h,
-        enable => ask,
+        enable => enable,
         nextPort => prox,
         ready => ready
     );
@@ -131,10 +130,12 @@ begin
                     mux_out <= (others=>(others=>'0'));
                     source <= (others=>(others=>'0'));
                 when S1=>
+                    enable <= ask;
                     ceTable <= '0';
                     ack_h <= (others => '0');
                 when S2=>
                     sel <= prox;
+                    enable <= not ready;
                 when S3 =>
                     if address /= header then
                         ceTable <= '1';

--- a/Teste/NoC/Thor_switchcontrol.vhd
+++ b/Teste/NoC/Thor_switchcontrol.vhd
@@ -79,7 +79,7 @@ begin
     begin
         if reset='1' then
             ES<=S0;
-        elsif clock'event and clock='0' then
+        elsif clock'event and clock='1' then
             ES<=PES;
         end if;
     end process;

--- a/Teste/NoC/Thor_switchcontrol.vhd
+++ b/Teste/NoC/Thor_switchcontrol.vhd
@@ -28,6 +28,8 @@ architecture RoutingTable of SwitchControl is
     signal sel,prox: integer range 0 to (NPORT-1) := 0;
     signal incoming: reg3 := (others=> '0');
     signal header : regflit := (others=> '0');
+    signal ready, enable : std_logic;
+
     signal indice_dir: integer range 0 to (NPORT-1) := 0;
     signal auxfree: regNport := (others=> '0');
     signal source:  arrayNport_reg3 := (others=> (others=> '0'));
@@ -44,41 +46,14 @@ begin
     incoming <= CONV_VECTOR(sel);
     header <= data(TO_INTEGER(unsigned(incoming)));
 
-    process(sel, h)
-    begin
-        case sel is
-            when LOCAL=>
-                if h(EAST)='1' then prox<=EAST;
-                elsif h(WEST)='1' then prox<=WEST;
-                elsif h(NORTH)='1' then prox<=NORTH;
-                elsif h(SOUTH)='1' then prox<=SOUTH;
-                else prox<=LOCAL; end if;
-            when EAST=>
-                if h(WEST)='1' then prox<=WEST;
-                elsif h(NORTH)='1' then prox<=NORTH;
-                elsif h(SOUTH)='1' then prox<=SOUTH;
-                elsif h(LOCAL)='1' then prox<=LOCAL;
-                else prox<=EAST; end if;
-            when WEST=>
-                if h(NORTH)='1' then prox<=NORTH;
-                elsif h(SOUTH)='1' then prox<=SOUTH;
-                elsif h(LOCAL)='1' then prox<=LOCAL;
-                elsif h(EAST)='1' then prox<=EAST;
-                else prox<=WEST; end if;
-            when NORTH=>
-                if h(SOUTH)='1' then prox<=SOUTH;
-                elsif h(LOCAL)='1' then prox<=LOCAL;
-                elsif h(EAST)='1' then prox<=EAST;
-                elsif h(WEST)='1' then prox<=WEST;
-                else prox<=NORTH; end if;
-            when SOUTH=>
-                if h(LOCAL)='1' then prox<=LOCAL;
-                elsif h(EAST)='1' then prox<=EAST;
-                elsif h(WEST)='1' then prox<=WEST;
-                elsif h(NORTH)='1' then prox<=NORTH;
-                else prox<=SOUTH; end if;
-        end case;
-    end process;
+    InputArbiter : entity work.inputArbiter
+    port map(
+        lastPort => sel,
+        requests => h,
+        enable => ask,
+        nextPort => prox,
+        ready => ready
+    );
 
     RoutingMechanism : entity work.routingMechanism
     generic map(ramInit => ramInit)

--- a/Teste/NoC/inputArbiter.vhd
+++ b/Teste/NoC/inputArbiter.vhd
@@ -1,0 +1,65 @@
+library IEEE;
+use IEEE.STD_LOGIC_1164.all;
+use IEEE.STD_LOGIC_unsigned.all;
+use work.ThorPackage.all;
+use work.TablePackage.all;
+
+entity inputArbiter is
+port(
+    lastPort :    in	integer range 0 to (NPORT-1);
+    requests :    in    regNport;
+    enable :    in    std_logic;
+    nextPort :    out    integer range 0 to (NPORT-1);
+    ready :    out    std_logic
+);
+end inputArbiter;
+
+architecture RoundRobin of inputArbiter is
+
+begin
+
+    process(lastPort, requests, enable)
+    begin
+        if(enable = '1') then
+            case lastPort is
+                when LOCAL=>
+                    if requests(EAST)='1' then nextPort<=EAST;
+                    elsif requests(WEST)='1' then nextPort<=WEST;
+                    elsif requests(NORTH)='1' then nextPort<=NORTH;
+                    elsif requests(SOUTH)='1' then nextPort<=SOUTH;
+                    else nextPort<=LOCAL; end if;
+                    ready <= '1';
+                when EAST=>
+                    if requests(WEST)='1' then nextPort<=WEST;
+                    elsif requests(NORTH)='1' then nextPort<=NORTH;
+                    elsif requests(SOUTH)='1' then nextPort<=SOUTH;
+                    elsif requests(LOCAL)='1' then nextPort<=LOCAL;
+                    else nextPort<=EAST; end if;
+                    ready <= '1';
+                when WEST=>
+                    if requests(NORTH)='1' then nextPort<=NORTH;
+                    elsif requests(SOUTH)='1' then nextPort<=SOUTH;
+                    elsif requests(LOCAL)='1' then nextPort<=LOCAL;
+                    elsif requests(EAST)='1' then nextPort<=EAST;
+                    else nextPort<=WEST; end if;
+                    ready <= '1';
+                when NORTH=>
+                    if requests(SOUTH)='1' then nextPort<=SOUTH;
+                    elsif requests(LOCAL)='1' then nextPort<=LOCAL;
+                    elsif requests(EAST)='1' then nextPort<=EAST;
+                    elsif requests(WEST)='1' then nextPort<=WEST;
+                    else nextPort<=NORTH; end if;
+                    ready <= '1';
+                when SOUTH=>
+                    if requests(LOCAL)='1' then nextPort<=LOCAL;
+                    elsif requests(EAST)='1' then nextPort<=EAST;
+                    elsif requests(WEST)='1' then nextPort<=WEST;
+                    elsif requests(NORTH)='1' then nextPort<=NORTH;
+                    else nextPort<=SOUTH; end if;
+                    ready <= '1';
+            end case;
+        else ready <= '0';
+        end if;
+    end process;
+
+end RoundRobin;

--- a/Teste/NoC/inputArbiter.vhd
+++ b/Teste/NoC/inputArbiter.vhd
@@ -6,60 +6,60 @@ use work.TablePackage.all;
 
 entity inputArbiter is
 port(
-    lastPort :    in	integer range 0 to (NPORT-1);
-    requests :    in    regNport;
-    enable :    in    std_logic;
-    nextPort :    out    integer range 0 to (NPORT-1);
-    ready :    out    std_logic
+    requests : in regNport;
+    enable : in std_logic;
+    nextPort : out integer range 0 to (NPORT-1);
+    ready : out std_logic
 );
 end inputArbiter;
 
 architecture RoundRobin of inputArbiter is
 
+    signal lastPort : integer range 0 to (NPORT-1) := EAST;
+
 begin
 
-    process(lastPort, requests, enable)
+    process(enable)
+        variable designedPort : integer range 0 to (NPORT-1);
     begin
-        if(enable = '1') then
+        if(enable'event and enable = '1') then
             case lastPort is
                 when LOCAL=>
-                    if requests(EAST)='1' then nextPort<=EAST;
-                    elsif requests(WEST)='1' then nextPort<=WEST;
-                    elsif requests(NORTH)='1' then nextPort<=NORTH;
-                    elsif requests(SOUTH)='1' then nextPort<=SOUTH;
-                    else nextPort<=LOCAL; end if;
-                    ready <= '1';
+                    if requests(EAST)='1' then designedPort := EAST;
+                    elsif requests(WEST)='1' then designedPort := WEST;
+                    elsif requests(NORTH)='1' then designedPort := NORTH;
+                    elsif requests(SOUTH)='1' then designedPort := SOUTH;
+                    else designedPort := LOCAL; end if;
                 when EAST=>
-                    if requests(WEST)='1' then nextPort<=WEST;
-                    elsif requests(NORTH)='1' then nextPort<=NORTH;
-                    elsif requests(SOUTH)='1' then nextPort<=SOUTH;
-                    elsif requests(LOCAL)='1' then nextPort<=LOCAL;
-                    else nextPort<=EAST; end if;
-                    ready <= '1';
+                    if requests(WEST)='1' then designedPort := WEST;
+                    elsif requests(NORTH)='1' then designedPort := NORTH;
+                    elsif requests(SOUTH)='1' then designedPort := SOUTH;
+                    elsif requests(LOCAL)='1' then designedPort := LOCAL;
+                    else designedPort := EAST; end if;
                 when WEST=>
-                    if requests(NORTH)='1' then nextPort<=NORTH;
-                    elsif requests(SOUTH)='1' then nextPort<=SOUTH;
-                    elsif requests(LOCAL)='1' then nextPort<=LOCAL;
-                    elsif requests(EAST)='1' then nextPort<=EAST;
-                    else nextPort<=WEST; end if;
-                    ready <= '1';
+                    if requests(NORTH)='1' then designedPort := NORTH;
+                    elsif requests(SOUTH)='1' then designedPort := SOUTH;
+                    elsif requests(LOCAL)='1' then designedPort := LOCAL;
+                    elsif requests(EAST)='1' then designedPort := EAST;
+                    else designedPort := WEST; end if;
                 when NORTH=>
-                    if requests(SOUTH)='1' then nextPort<=SOUTH;
-                    elsif requests(LOCAL)='1' then nextPort<=LOCAL;
-                    elsif requests(EAST)='1' then nextPort<=EAST;
-                    elsif requests(WEST)='1' then nextPort<=WEST;
-                    else nextPort<=NORTH; end if;
-                    ready <= '1';
+                    if requests(SOUTH)='1' then designedPort := SOUTH;
+                    elsif requests(LOCAL)='1' then designedPort := LOCAL;
+                    elsif requests(EAST)='1' then designedPort := EAST;
+                    elsif requests(WEST)='1' then designedPort := WEST;
+                    else designedPort := NORTH; end if;
                 when SOUTH=>
-                    if requests(LOCAL)='1' then nextPort<=LOCAL;
-                    elsif requests(EAST)='1' then nextPort<=EAST;
-                    elsif requests(WEST)='1' then nextPort<=WEST;
-                    elsif requests(NORTH)='1' then nextPort<=NORTH;
-                    else nextPort<=SOUTH; end if;
-                    ready <= '1';
+                    if requests(LOCAL)='1' then designedPort := LOCAL;
+                    elsif requests(EAST)='1' then designedPort := EAST;
+                    elsif requests(WEST)='1' then designedPort := WEST;
+                    elsif requests(NORTH)='1' then designedPort := NORTH;
+                    else designedPort := SOUTH; end if;
             end case;
-        else ready <= '0';
+            lastPort <= designedPort;
+            nextPort <= designedPort;
         end if;
     end process;
+
+    ready <= enable;
 
 end RoundRobin;

--- a/Teste/comp.do
+++ b/Teste/comp.do
@@ -19,6 +19,7 @@ set source_files {
     NoC/fifo_buffer.vhd
     NoC/Thor_buffer.vhd
     NoC/outputArbiter.vhd
+    NoC/inputArbiter.vhd
     NoC/Thor_switchcontrol.vhd
     NoC/Thor_crossbar.vhd
     NoC/RouterCC.vhd


### PR DESCRIPTION
The new entity/architecture that refers to input arbiter was created and mapped on switch control. Also, all the code that once referred to the input arbiter description was deleted on switch control.