### PR TITLE
Fix auxfree assignment

### DIFF
--- a/Teste/NoC/Thor_switchcontrol.vhd
+++ b/Teste/NoC/Thor_switchcontrol.vhd
@@ -192,8 +192,6 @@ begin
             for i in EAST to LOCAL loop
                 if sender(i)='0' and  sender_ant(i)='1' then 
                     auxfree(CONV_INTEGER(source(i))) <= '1'; 
-                else
-                    auxfree(CONV_INTEGER(source(i))) <= '0'; 
                 end if;
             end loop;
 


### PR DESCRIPTION
Fix the way that the auxfree flags are raised. This bug was introduced by the commit 9527d4.