### PR TITLE
Replace the clock event verification

### DIFF
--- a/Teste/NoC/Thor_buffer.vhd
+++ b/Teste/NoC/Thor_buffer.vhd
@@ -63,7 +63,7 @@ begin
             pull <= '0';
             sender <=  '0';
             EA <= S_INIT;
-        elsif clock'event and clock = '1' then
+        elsif rising_edge(clock) then
             case EA is
                 when S_INIT =>
                     counter_flit <= 0;

--- a/Teste/NoC/Thor_switchcontrol.vhd
+++ b/Teste/NoC/Thor_switchcontrol.vhd
@@ -79,7 +79,7 @@ begin
     begin
         if reset='1' then
             ES<=S0;
-        elsif clock'event and clock='1' then
+        elsif rising_edge(clock) then
             ES<=PES;
         end if;
     end process;
@@ -119,7 +119,7 @@ begin
 
     process(clock)
     begin
-        if clock'event and clock='1' then
+        if rising_edge(clock) then
             case ES is
                 when S0 =>
                     ceTable <= '0';

--- a/Teste/NoC/fifo_buffer.vhd
+++ b/Teste/NoC/fifo_buffer.vhd
@@ -40,7 +40,7 @@ begin
     begin
         if reset = '1' then
             last <= 0;
-        elsif clock'event and clock = '1' then
+        elsif rising_edge(clock) then
             if not isFull and push = '1' then
                 buf(last) <= tail;
                 if last = B_DEPTH then
@@ -55,7 +55,7 @@ begin
     begin
         if reset = '1' then
             first <= 0;
-        elsif clock'event and clock = '1' then
+        elsif rising_edge(clock) then
             if not isEmpty and pull = '1' then
                 if first = B_DEPTH then
                     first <= 0;

--- a/Teste/NoC/inputArbiter.vhd
+++ b/Teste/NoC/inputArbiter.vhd
@@ -22,7 +22,7 @@ begin
     process(enable)
         variable designedPort : integer range 0 to (NPORT-1);
     begin
-        if(enable'event and enable = '1') then
+        if rising_edge(enable) then
             case lastPort is
                 when LOCAL=>
                     if requests(EAST)='1' then designedPort := EAST;


### PR DESCRIPTION
Every (clock'event and clock='1') condition were changed to rising_edge(clock). It's a implemented function in std_logic_1164 library to ensure that this condition is bug free (i.e. last value was 'Z'). Only considering TRUE if the event is coming from the value '0' to value '1', otherwise FALSE.