### PR TITLE
Fix buffer depth

### DIFF
--- a/NoC/Thor_buffer.vhd
+++ b/NoC/Thor_buffer.vhd
@@ -50,7 +50,7 @@ begin
 
     data <= bufferHead;
     data_av <= has_data_and_sending;
-    credit_o <= '1' when (counter /= TAM_BUFFER) else '0';
+    credit_o <= '1' when (counter /= TAM_BUFFER or pull = '1') else '0';
     sender <= sending;
     h <= has_data and not sending;
 

--- a/NoC/Thor_buffer.vhd
+++ b/NoC/Thor_buffer.vhd
@@ -35,9 +35,9 @@ signal sent : std_logic;
 
 begin
 
-    circularFifoBuffer : entity work.FifoBuffer
-    generic map(B_DEPTH => TAM_BUFFER ,
-                B_WIDTH => regflit'length)
+    circularFifoBuffer : entity work.fifo_buffer
+    generic map(BUFFER_DEPTH => TAM_BUFFER ,
+                BUFFER_WIDTH => regflit'length)
     port map(
         reset =>     reset,
         clock =>     clock_rx,

--- a/NoC/fifo_buffer.vhd
+++ b/NoC/fifo_buffer.vhd
@@ -1,48 +1,47 @@
 library IEEE;
 use IEEE.STD_LOGIC_1164.all;
-use ieee.numeric_std.all;
 
-entity fifoBuffer is
+entity fifo_buffer is
     generic(
-        B_DEPTH : positive;
-        B_WIDTH : positive
+        BUFFER_DEPTH : positive;
+        BUFFER_WIDTH : positive
     );
     port(
         reset :     in std_logic;
         clock :     in std_logic;
-        head:       out std_logic_vector(B_WIDTH-1 downto 0);
-        tail :      in std_logic_vector(B_WIDTH-1 downto 0);
+        head:       out std_logic_vector(BUFFER_WIDTH-1 downto 0);
+        tail :      in std_logic_vector(BUFFER_WIDTH-1 downto 0);
         push :      in std_logic;
         pull :      in std_logic;
         counter :   out natural
     );
 end;
 
-architecture circularFifoBuffer of FifoBuffer is
+architecture circular_fifo_buffer of fifo_buffer is
 
-    type buff is array(0 to B_DEPTH - 1) of std_logic_vector(B_WIDTH-1 downto 0);
-    subtype pointer is natural range 0 to B_DEPTH - 1;
-
-    signal buf: buff := (others=>(others=>'0'));
-    signal isFull : boolean;
-    signal first: pointer;
-    signal last: pointer;
+    type buff is array(0 to BUFFER_DEPTH - 1) of std_logic_vector(BUFFER_WIDTH-1 downto 0);
+    subtype pointer is natural range 0 to BUFFER_DEPTH - 1;
 
     procedure increment_pointer(p: inout pointer) is
     begin
-        if p = B_DEPTH - 1 then
+        if p = BUFFER_DEPTH - 1 then
             p := 0;
         else
             p := p + 1;
         end if;
     end increment_pointer;
 
+    signal buf: buff := (others=>(others=>'0'));
+    signal is_full : boolean;
+    signal first: pointer;
+    signal last: pointer;
+
 begin
 
     head <= buf(first);
-    counter <=   B_DEPTH when isFull else
-                    last - first when (last >= first) else
-                    B_DEPTH - (first - last);
+    counter <=  BUFFER_DEPTH when is_full else
+                last - first when (last >= first) else
+                BUFFER_DEPTH - (first - last);
 
     process(reset, clock)
         variable aux_first, aux_last: pointer;
@@ -51,12 +50,12 @@ begin
         if reset = '1' then
             last <= 0;
             first <= 0;
-            isFull <= false;
+            is_full <= false;
             is_empty := true;
-            aux_is_full := false;
-            aux_last := 0;
-            aux_first := 0;
         elsif rising_edge(clock) then
+            aux_is_full := is_full;
+            aux_last := last;
+            aux_first := first;
             -- remove data
             if not is_empty and pull = '1' then
                 increment_pointer(aux_first);
@@ -70,10 +69,10 @@ begin
                 is_empty := false;
                 aux_is_full := (aux_last = aux_first);
             end if;
-            isFull <= aux_is_full;
+            is_full <= aux_is_full;
             last <= aux_last;
             first <= aux_first;
         end if;
     end process;
 
-end circularFifoBuffer;
+end circular_fifo_buffer;

--- a/NoC/fifo_buffer.vhd
+++ b/NoC/fifo_buffer.vhd
@@ -4,8 +4,8 @@ use ieee.numeric_std.all;
 
 entity fifoBuffer is
     generic(
-        B_DEPTH : natural;
-        B_WIDTH : natural
+        B_DEPTH : positive;
+        B_WIDTH : positive
     );
     port(
         reset :     in std_logic;
@@ -14,7 +14,7 @@ entity fifoBuffer is
         tail :      in std_logic_vector(B_WIDTH-1 downto 0);
         push :      in std_logic;
         pull :      in std_logic;
-        counter :   out integer
+        counter :   out natural
     );
 end;
 
@@ -24,9 +24,9 @@ architecture circularFifoBuffer of FifoBuffer is
     signal buf: buff := (others=>(others=>'0'));
 
     signal isFull, isEmpty : boolean;
-    signal first: integer := 0;
-    signal last: integer := 0;
-    signal auxCounter: integer;
+    signal first: natural range 0 to B_DEPTH := 0;
+    signal last: natural range 0 to B_DEPTH := 0;
+    signal auxCounter: natural;
 
 begin
 

--- a/NoC/fifo_buffer.vhd
+++ b/NoC/fifo_buffer.vhd
@@ -20,49 +20,59 @@ end;
 
 architecture circularFifoBuffer of FifoBuffer is
 
-    type buff is array(0 to B_DEPTH) of std_logic_vector(B_WIDTH-1 downto 0);
-    signal buf: buff := (others=>(others=>'0'));
+    type buff is array(0 to B_DEPTH - 1) of std_logic_vector(B_WIDTH-1 downto 0);
+    subtype pointer is natural range 0 to B_DEPTH - 1;
 
-    signal isFull, isEmpty : boolean;
-    signal first: natural range 0 to B_DEPTH := 0;
-    signal last: natural range 0 to B_DEPTH := 0;
-    signal auxCounter: natural;
+    signal buf: buff := (others=>(others=>'0'));
+    signal isFull : boolean;
+    signal first: pointer;
+    signal last: pointer;
+
+    procedure increment_pointer(p: inout pointer) is
+    begin
+        if p = B_DEPTH - 1 then
+            p := 0;
+        else
+            p := p + 1;
+        end if;
+    end increment_pointer;
 
 begin
 
-    counter <= auxCounter;
     head <= buf(first);
-    auxCounter <= last - first when (last >= first) else B_DEPTH + 1 - (first - last);
-    isFull <= auxCounter = B_DEPTH;
-    isEmpty <= auxCounter = 0;
+    counter <=   B_DEPTH when isFull else
+                    last - first when (last >= first) else
+                    B_DEPTH - (first - last);
 
     process(reset, clock)
+        variable aux_first, aux_last: pointer;
+        variable aux_is_full, is_empty : boolean;
     begin
         if reset = '1' then
             last <= 0;
-        elsif rising_edge(clock) then
-            if not isFull and push = '1' then
-                buf(last) <= tail;
-                if last = B_DEPTH then
-                    last <= 0;
-                else last <= last + 1;
-                end if;
-            end if;
-        end if;
-    end process;
-
-    process (reset, clock)
-    begin
-        if reset = '1' then
             first <= 0;
+            isFull <= false;
+            is_empty := true;
+            aux_is_full := false;
+            aux_last := 0;
+            aux_first := 0;
         elsif rising_edge(clock) then
-            if not isEmpty and pull = '1' then
-                if first = B_DEPTH then
-                    first <= 0;
-                else
-                    first <= first + 1;
-                end if;
+            -- remove data
+            if not is_empty and pull = '1' then
+                increment_pointer(aux_first);
+                aux_is_full := false;
+                is_empty := (aux_first = aux_last);
             end if;
+            -- append data
+            if not aux_is_full and push = '1' then
+                buf(aux_last) <= tail;
+                increment_pointer(aux_last);
+                is_empty := false;
+                aux_is_full := (aux_last = aux_first);
+            end if;
+            isFull <= aux_is_full;
+            last <= aux_last;
+            first <= aux_first;
         end if;
     end process;
 

--- a/runtests.do
+++ b/runtests.do
@@ -1,0 +1,22 @@
+exit -sim
+vlib work
+vmap work work
+
+proc comp_vhdl {vhdl_source} {
+    vcom -work work -93 -explicit -bindAtCompile -check_synthesis -fsmverbose w\
+    -lint -noDeferSubpgmCheck -nologo -pedanticerrors\
+    -quiet -rangecheck $vhdl_source
+}
+
+set source_files {
+    NoC/fifo_buffer.vhd
+    tests/fifo_buffer_test.vhd
+}
+
+foreach file $source_files {
+    comp_vhdl $file
+}
+
+vsim -voptargs="+noassertdebug+O5" -onfinish stop work.fifo_buffer_test
+run 1 ms
+quit -sim

--- a/tests/fifo_buffer_test.vhd
+++ b/tests/fifo_buffer_test.vhd
@@ -1,0 +1,82 @@
+library IEEE;
+use IEEE.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity fifo_buffer_test is
+end;
+
+architecture fifo_buffer_test of fifo_buffer_test is
+
+    constant CLOCK_PERIOD : time := 20 ns;
+    constant BUFFER_DEPTH : positive := 10;
+    constant BUFFER_WIDTH : positive := 13;
+
+    signal clock:          std_logic := '0';
+    signal reset:          std_logic;
+    signal head, tail : std_logic_vector(BUFFER_WIDTH-1 downto 0);
+    signal push, pull : std_logic;
+    signal counter : natural;
+
+    procedure wait_clock_tick is
+    begin
+        wait until rising_edge(clock);
+        wait until counter'stable;
+        wait until head'stable;
+    end wait_clock_tick;
+
+begin
+    reset <= '1', '0' after CLOCK_PERIOD/4;
+    clock <= not clock after CLOCK_PERIOD/2;
+
+    UUT : entity work.fifoBuffer
+    generic map(
+        B_DEPTH => BUFFER_DEPTH,
+        B_WIDTH => BUFFER_WIDTH)
+    port map(
+        reset => reset,
+        clock => clock,
+        head => head,
+        tail => tail,
+        push => push,
+        pull => pull,
+        counter => counter
+    );
+
+    process
+    begin
+        push <= '0';
+        pull <= '0';
+        tail <= (others=>'0');
+        wait until reset = '0';
+        assert counter = 0 report "Buffer should be empty after reset" severity failure;
+        wait_clock_tick;
+        -- fill it completely
+        push <= '1';
+        for i in 1 to BUFFER_DEPTH loop
+            tail <= std_logic_vector(to_unsigned(i, tail'length));
+            wait_clock_tick;
+            assert counter = i report "Buffer should have " & integer'image(i) & " element(s)" severity failure;
+        end loop;
+        -- try to force one more
+        wait_clock_tick;
+        assert counter = BUFFER_DEPTH report "Buffer shouldnt pass its size" severity failure;
+        -- push and pull at the same time
+        pull <= '1';
+        for i in 1 to BUFFER_DEPTH loop
+            assert head = std_logic_vector(to_unsigned(i, head'length)) report "Values not equal when pushing/pulling" severity failure;
+            tail <= std_logic_vector(to_unsigned(i, tail'length));
+            wait_clock_tick;
+            assert counter = BUFFER_DEPTH report "Buffer counter should remain constant when pushing/pulling" severity failure;
+        end loop;
+        -- empty it completely
+        push <= '0';
+        for i in 1 to BUFFER_DEPTH loop
+            assert head = std_logic_vector(to_unsigned(i, head'length)) report "Values not equal when emptying" severity failure;
+            wait_clock_tick;
+            assert counter = (BUFFER_DEPTH  - i) report "Buffer should have " & integer'image(BUFFER_DEPTH  - i) & " element(s)" severity failure;
+        end loop;
+
+        wait;
+    end process;
+
+end fifo_buffer_test;

--- a/tests/fifo_buffer_test.vhd
+++ b/tests/fifo_buffer_test.vhd
@@ -28,10 +28,10 @@ begin
     reset <= '1', '0' after CLOCK_PERIOD/4;
     clock <= not clock after CLOCK_PERIOD/2;
 
-    UUT : entity work.fifoBuffer
+    UUT : entity work.fifo_buffer
     generic map(
-        B_DEPTH => BUFFER_DEPTH,
-        B_WIDTH => BUFFER_WIDTH)
+        BUFFER_DEPTH => BUFFER_DEPTH,
+        BUFFER_WIDTH => BUFFER_WIDTH)
     port map(
         reset => reset,
         clock => clock,


### PR DESCRIPTION
Changes fifo buffer design so that it can have the right depth and correctly keep its counter consistent (differentiate the full and empty states).
With that it is possible to receive data when it's full given that, at the same time, data is being pulled out.

Commit: Fix, Mod, Ref

TaskNumber: #63